### PR TITLE
FI-2253: Loosen jwt dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     fast_security_test_kit (0.1.0)
       inferno_core (>= 0.4.2)
-      jwt (~> 2.3.0)
+      jwt (~> 2.3)
 
 GEM
   remote: https://rubygems.org/

--- a/fast_security_test_kit.gemspec
+++ b/fast_security_test_kit.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/inferno-framework/fast-security-test-kit'
   spec.license       = 'Apache-2.0'
   spec.add_runtime_dependency 'inferno_core', '>= 0.4.2'
-  spec.add_runtime_dependency 'jwt', '~> 2.3.0'
+  spec.add_runtime_dependency 'jwt', '~> 2.3'
   spec.add_development_dependency 'database_cleaner-sequel', '~> 1.8'
   spec.add_development_dependency 'factory_bot', '~> 6.1'
   spec.add_development_dependency 'rspec', '~> 3.10'


### PR DESCRIPTION
# Summary
This branch loosens the jwt version requirement so that this test kit will be compatible with the SMART App Launch Test Kit.

# Testing Guidance
There should be no changes in behavior.