### PR TITLE
FI-2496 Discovery Test Updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-linux
 
@@ -292,4 +293,4 @@ DEPENDENCIES
   webmock (~> 3.11)
 
 BUNDLED WITH
-   2.3.23
+   2.5.3

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -240,7 +240,7 @@ module FASTSecurity
       title 'token_endpoint_auth_signing_alg_values_supported field'
       description %(
        `token_endpoint_auth_signing_alg_values_supported` is an
-        array of one or more strings identifying signature algorithms
+        array of one or more strings identifying signature algorithms supported by the Authorization Server for validation of signed JWTs submitted to the token endpoint for client authentication.
       )
 
       input :config_json
@@ -286,7 +286,7 @@ module FASTSecurity
       title 'registration_endpoint_jwt_signing_alg_values_supported field'
       description %(
         If present, `registration_endpoint_jwt_signing_alg_values_supported` is
-        an array of one or more strings identifying signature algorithms
+        an array of one or more strings identifying signature algorithms supported by the Authorization Server for validation of signed software statements, certifications, and endorsements submitted to the registration endpoint.
       )
 
       input :config_json
@@ -295,7 +295,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('registration_endpoint_jwt_signing_alg_values_supported')
+        omit_if !config.key?('registration_endpoint_jwt_signing_alg_values_supported'), '`registration_endpoint_jwt_signing_alg_values_supported` field is recommended but not required'
 
         assert_array_of_strings(config, 'registration_endpoint_jwt_signing_alg_values_supported')
       end

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -1,5 +1,4 @@
 # coding: utf-8
-require 'pry'
 require 'jwt'
 
 module FASTSecurity

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -218,7 +218,7 @@ module FASTSecurity
     test do
       title 'token_endpoint_auth_methods_supported field'
       description %(
-        If present, `token_endpoint_auth_methods_supported` must contain a fixed
+        `token_endpoint_auth_methods_supported` must contain a fixed
         array with one string element: `["private_key_jwt"]`
       )
 
@@ -228,7 +228,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('token_endpoint_auth_methods_supported')
+        assert config.key?('token_endpoint_auth_methods_supported'), '`token_endpoint_auth_methods_supported` is a required field'
 
         assert config['token_endpoint_auth_methods_supported'] == ['private_key_jwt'],
                "`token_endpoint_auth_methods_supported` field must contain an array " \

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+require 'pry'
 require 'jwt'
 
 module FASTSecurity
@@ -168,8 +169,7 @@ module FASTSecurity
     test do
       title 'authorization_endpoint field'
       description %(
-        If present, `authorization_endpoint` is a string containing the URL of
-        the Authorization Server's authorization endpoint
+        A string containing the absolute URL of the Authorization Server's authorization endpoint. This parameter SHALL be present if the value of the grant_types_supported parameter includes the string "authorization_code"
       )
 
       input :config_json
@@ -178,7 +178,11 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('authorization_endpoint')
+        skip_if (!config.key?('grant_types_supported') || !config['grant_types_supported'].is_a?(Array)), 'Assessment of `authorization_endpoint` field is dependent on values in `grant_types_supported` field, which is not present or correctly formatted'
+
+        omit_if !config['grant_types_supported'].include?('authorization_code'), '`authorization_endpoint` field is only required if `authorization_code` is a supported grant type'
+
+        assert config.key?('authorization_endpoint'), '`authorization_endpoint` field is required if `authorization_endpoint` is a supported grant type'
 
         endpoint = config['authorization_endpoint']
 

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -65,7 +65,7 @@ module FASTSecurity
     test do
       title 'udap_certifications_supported field'
       description %(
-        If present, `udap_certifications_supported` is an array of zero or more
+        `udap_certifications_supported` is an array of zero or more
         certification URIs
       )
 
@@ -75,7 +75,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        assert config.key?('udap_certifications_supported'), "`udap_certifications_supported is a required parameter"
+        assert config.key?('udap_certifications_supported'), "`udap_certifications_supported` is a required field"
 
         assert_array_of_strings(config, 'udap_certifications_supported')
 
@@ -130,7 +130,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        assert config.key?('grant_types_supported'), "`grant_types_supported` is a required parameter"
+        assert config.key?('grant_types_supported'), "`grant_types_supported` is a required field"
 
         assert_array_of_strings(config, 'grant_types_supported')
 
@@ -168,7 +168,7 @@ module FASTSecurity
     test do
       title 'authorization_endpoint field'
       description %(
-        A string containing the absolute URL of the Authorization Server's authorization endpoint. This parameter SHALL be present if the value of the grant_types_supported parameter includes the string "authorization_code"
+        `authorization_endpoint` is a string containing the absolute URL of the Authorization Server's authorization endpoint. This parameter SHALL be present if the value of the grant_types_supported parameter includes the string "authorization_code"
       )
 
       input :config_json
@@ -226,8 +226,6 @@ module FASTSecurity
       run do
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
-
-        assert config.key?('token_endpoint_auth_methods_supported'), '`token_endpoint_auth_methods_supported` is a required field'
 
         assert config['token_endpoint_auth_methods_supported'] == ['private_key_jwt'],
                "`token_endpoint_auth_methods_supported` field must contain an array " \
@@ -303,7 +301,7 @@ module FASTSecurity
     test do
       title 'signed_metadata field'
       description %(
-        If present, `signed_metadata` is a string containing a JWT
+       `signed_metadata` is a string containing a JWT listing the server's endpoints
       )
 
       input :config_json
@@ -394,13 +392,11 @@ module FASTSecurity
     test do 
       title 'udap_profiles_supported field'
       description %(
-        An array of two or more strings identifying the core UDAP profiles supported by the Authorization Server. The array SHALL include:
-        "udap_dcr" for UDAP Dynamic Client Registration, and
-        "udap_authn" for UDAP JWT-Based Client Authentication.
-        If the grant_types_supported parameter includes the string "client_credentials", then the array SHALL also include:
-        "udap_authz" for UDAP Client Authorization Grants using JSON Web Tokens to indicate support for Authorization Extension Objects.
-        If the server supports the user authentication workflow described in Section 6, then the array SHALL also include:
-        "udap_to" for UDAP Tiered OAuth for User Authentication.
+        `udap_profiles_supported` is an array of two or more strings identifying the core UDAP profiles supported by the Authorization Server. The array SHALL include:
+        `udap_dcr` for UDAP Dynamic Client Registration, and
+        `udap_authn` for UDAP JWT-Based Client Authentication.
+        If the `grant_types_supported` parameter includes the string `client_credentials`, then the array SHALL also include:
+        `udap_authz` for UDAP Client Authorization Grants using JSON Web Tokens to indicate support for Authorization Extension Objects.
       )
 
       input :config_json
@@ -428,7 +424,7 @@ module FASTSecurity
     test do
       title 'udap_authorization_extensions_supported field'
       description %(
-        An array of zero or more recognized key names for Authorization Extension Objects supported by the Authorization Server.
+        `udap_authorization_extensions_supported` is an array of zero or more recognized key names for Authorization Extension Objects supported by the Authorization Server.
       )
 
       input :config_json
@@ -446,7 +442,7 @@ module FASTSecurity
     test do 
       title 'udap_authorization_extensions_required field'
       description %(
-        An array of zero or more recognized key names for Authorization Extension Objects required by the Authorization Server in every token request. This metadata parameter SHALL be present if the value of the udap_authorization_extensions_supported parameter is not an empty array.
+        `udap_authorization_extensions_required field` is an array of zero or more recognized key names for Authorization Extension Objects required by the Authorization Server in every token request. This metadata parameter SHALL be present if the value of the `udap_authorization_extensions_supported` parameter is not an empty array.
       )
 
       input :config_json

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -391,5 +391,39 @@ module FASTSecurity
         )
       end
     end
+  
+    test do 
+      title 'udap_profiles_supported field'
+      description %(
+        An array of two or more strings identifying the core UDAP profiles supported by the Authorization Server. The array SHALL include:
+        "udap_dcr" for UDAP Dynamic Client Registration, and
+        "udap_authn" for UDAP JWT-Based Client Authentication.
+        If the grant_types_supported parameter includes the string "client_credentials", then the array SHALL also include:
+        "udap_authz" for UDAP Client Authorization Grants using JSON Web Tokens to indicate support for Authorization Extension Objects.
+        If the server supports the user authentication workflow described in Section 6, then the array SHALL also include:
+        "udap_to" for UDAP Tiered OAuth for User Authentication.
+      )
+
+      input :config_json
+
+      run do 
+        assert_valid_json(config_json)
+        config = JSON.parse(config_json)
+
+        assert config.key?('udap_profiles_supported'), '`udap_profiles_supported` is a required field'
+
+        assert_array_of_strings(config, 'udap_profiles_supported')
+
+        profiles_supported = config['udap_profiles_supported']
+        
+        assert profiles_supported.include?('udap_dcr'), 'Array must include `udap_dcr` to indicate support for required UDAP Dynamic Client Registration profile'
+
+        assert profiles_supported.include?('udap_authn'), 'Array must include `udap_authn` value to indicate support for required UDAP JWT-Based Client Authentication profile'
+
+        if (config.key?('grant_types_supported') && config['grant_types_supported'].include?('client_credentials'))
+          assert profiles_supported.include?('udap_authz'), '`client_credentials` grant type is supported, so array must include `udap_authz` to indicate support for UDAP Client Authorization Grants using JSON Web Tokens'
+        end
+      end
+    end
   end
 end

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -90,6 +90,33 @@ module FASTSecurity
     end
 
     test do
+      title 'udap_certifications_required field'
+      description %(
+        If present, `udap_certifications_required` is an array of zero or more
+        certification URIs
+      )
+
+      input :config_json
+
+      run do
+        assert_valid_json(config_json)
+        config = JSON.parse(config_json)
+
+        omit_if !config.key?('udap_certifications_required')
+
+        assert_array_of_strings(config, 'udap_certifications_required')
+
+        non_uri_values =
+          config['udap_certifications_required']
+            .select { |value| !value.match?(URI.regexp) }
+
+        assert non_uri_values.blank?,
+               '`udap_certifacations_required` should be an Array of URI strings, ' \
+               "but found #{non_uri_values.map(&:class).map(&:name).join(', ')}"
+      end
+    end
+    
+    test do
       title 'grant_types_supported field'
       description %(
         If present, `grant_types_supported` is an array of one or more
@@ -115,33 +142,6 @@ module FASTSecurity
                  'The `refresh_token` grant type **SHALL** only be included if the ' \
                  '`authorization_code` grant type is also included.'
         end
-      end
-    end
-
-    test do
-      title 'udap_certifications_required field'
-      description %(
-        If present, `udap_certifications_required` is an array of zero or more
-        certification URIs
-      )
-
-      input :config_json
-
-      run do
-        assert_valid_json(config_json)
-        config = JSON.parse(config_json)
-
-        omit_if !config.key?('udap_certifications_required')
-
-        assert_array_of_strings(config, 'udap_certifications_required')
-
-        non_uri_values =
-          config['udap_certifications_required']
-            .select { |value| !value.match?(URI.regexp) }
-
-        assert non_uri_values.blank?,
-               '`udap_certifacations_required` should be an Array of URI strings, ' \
-               "but found #{non_uri_values.map(&:class).map(&:name).join(', ')}"
       end
     end
 

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -262,7 +262,7 @@ module FASTSecurity
     test do
       title 'registration_endpoint field'
       description %(
-        If present, `registration_endpoint` is a string containing the URL of
+        `registration_endpoint` is a string containing the URL of
         the Authorization Server's registration endpoint
       )
 
@@ -272,7 +272,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('registration_endpoint')
+        assert config.key?('registration_endpoint'), '`registration_endpoint` is a required field'
 
         endpoint = config['registration_endpoint']
 

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -75,7 +75,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('udap_certifications_supported')
+        assert config.key?('udap_certifications_supported'), "`udap_certifications_supported is a required parameter"
 
         assert_array_of_strings(config, 'udap_certifications_supported')
 
@@ -92,7 +92,7 @@ module FASTSecurity
     test do
       title 'udap_certifications_required field'
       description %(
-        If present, `udap_certifications_required` is an array of zero or more
+        If `udap_certifications_supported` is not empty, then `udap_certifications_required` is an array of zero or more
         certification URIs
       )
 
@@ -102,7 +102,9 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('udap_certifications_required')
+        skip_if !config.key?('udap_certifications_supported'), 'Assessment of `udap_certifications_required` field is dependent on values in `udap_certifications_supported` field, which is not present'
+
+        omit_if config['udap_certifications_supported'].blank?, 'No UDAP certifications are supported'
 
         assert_array_of_strings(config, 'udap_certifications_required')
 
@@ -115,12 +117,11 @@ module FASTSecurity
                "but found #{non_uri_values.map(&:class).map(&:name).join(', ')}"
       end
     end
-    
+
     test do
       title 'grant_types_supported field'
       description %(
-        If present, `grant_types_supported` is an array of one or more
-        grant types
+        `grant_types_supported` is an array of one or more grant types
       )
 
       input :config_json

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -314,7 +314,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('signed_metadata')
+        assert config.key?('signed_metadata'), '`signed_metadata is a required field'
         jwt = config['signed_metadata']
 
         assert jwt.is_a?(String), "`signed_metadata` should be a String, but found #{jwt.class.name}"

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -195,7 +195,7 @@ module FASTSecurity
     test do
       title 'token_endpoint field'
       description %(
-        If present, `token_endpoint` is a string containing the URL of
+       `token_endpoint` is a string containing the URL of
         the Authorization Server's token endpoint
       )
 
@@ -205,7 +205,7 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('token_endpoint')
+        assert config.key?('token_endpoint'), '`token_endpoint` is a required field'
 
         endpoint = config['token_endpoint']
 

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -445,7 +445,25 @@ module FASTSecurity
     end
 
     test do 
+      title 'udap_authorization_extensions_required field'
+      description %(
+        An array of zero or more recognized key names for Authorization Extension Objects required by the Authorization Server in every token request. This metadata parameter SHALL be present if the value of the udap_authorization_extensions_supported parameter is not an empty array.
+      )
 
+      input :config_json
+
+      run do 
+        assert_valid_json(config_json)
+        config = JSON.parse(config_json)
+
+        skip_if !config.key?('udap_authorization_extensions_supported') || !config['udap_authorization_extensions_supported'].is_a?(Array), 'Assessment of `authorization_endpoint` field is dependent on values in `grant_types_supported` field, which is not present or correctly formatted'
+
+        omit_if config['udap_authorization_extensions_supported'].blank?, 'No UDAP authorization extensions are supported'
+
+        assert config.key?('udap_authorization_extensions_required'), '`udap_authorization_extensions_required` field must be present because `udap_authorization_extensions_supported field is not empty'
+
+        assert config['udap_authorization_extensions_required'].is_a?(Array), '`udap_authorization_extensions_required` must be an array'
+      end
     end
   end
 end

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -425,5 +425,27 @@ module FASTSecurity
         end
       end
     end
+
+    test do
+      title 'udap_authorization_extensions_supported field'
+      description %(
+        An array of zero or more recognized key names for Authorization Extension Objects supported by the Authorization Server.
+      )
+
+      input :config_json
+
+      run do
+        assert_valid_json(config_json)
+        config = JSON.parse(config_json)
+
+        assert config.key?('udap_authorization_extensions_supported'), '`udap_authorization_extensions_supported` is a required field'
+
+        assert config['udap_authorization_extensions_supported'].is_a?(Array), "`udap_authorization_extensions_supported` must be an array"
+      end
+    end
+
+    test do 
+
+    end
   end
 end

--- a/lib/fast_security/discovery_group.rb
+++ b/lib/fast_security/discovery_group.rb
@@ -239,7 +239,7 @@ module FASTSecurity
     test do
       title 'token_endpoint_auth_signing_alg_values_supported field'
       description %(
-        If present, `token_endpoint_auth_signing_alg_values_supported` is an
+       `token_endpoint_auth_signing_alg_values_supported` is an
         array of one or more strings identifying signature algorithms
       )
 
@@ -249,9 +249,13 @@ module FASTSecurity
         assert_valid_json(config_json)
         config = JSON.parse(config_json)
 
-        omit_if !config.key?('token_endpoint_auth_signing_alg_values_supported')
+        assert config.key?('token_endpoint_auth_signing_alg_values_supported'), '`token_endpoint_auth_signing_alg_values_supported` is a required field'
 
         assert_array_of_strings(config, 'token_endpoint_auth_signing_alg_values_supported')
+
+        algs_supported = config['token_endpoint_auth_signing_alg_values_supported']
+
+        assert algs_supported.length() >= 1, 'Must support at least one signature algorithm'
       end
     end
 

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -351,12 +351,12 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'token_endpoint field test' do
     let(:test) { group.tests[7] }
 
-    it 'omits if field is not present' do
+    it 'fails if field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
     end
 
     it 'passes if token_endpoint is a uri strings' do

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -464,15 +464,15 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'registration_endpoint field test' do
     let(:test) { group.tests[10] }
 
-    it 'omits if field is not present' do
+    it 'fails if field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
     end
 
-    it 'passes if registration_endpoint is a uri strings' do
+    it 'passes if registration_endpoint is a uri string' do
       config = { registration_endpoint: 'http://abc' }
 
       result = run(test, config_json: config.to_json)

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -418,16 +418,16 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'token_endpoint_auth_signing_alg_values_supported field test' do
     let(:test) { group.tests[9] }
 
-    it 'omits if field is not present' do
+    it 'fails if field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
     end
 
-    it 'passes if token_endpoint_auth_signing_alg_values_supported is an array of uri strings' do
-      config = { token_endpoint_auth_signing_alg_values_supported: ['http://abc', 'http://def'] }
+    it 'passes if token_endpoint_auth_signing_alg_values_supported is an array of one or more strings' do
+      config = { token_endpoint_auth_signing_alg_values_supported: ['RS256', 'ES384'] }
 
       result = run(test, config_json: config.to_json)
 
@@ -435,7 +435,7 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
     end
 
     it 'fails if token_endpoint_auth_signing_alg_values_supported is not an array' do
-      config = { token_endpoint_auth_signing_alg_values_supported: 'http://abc' }
+      config = { token_endpoint_auth_signing_alg_values_supported: 'RS256' }
 
       result = run(test, config_json: config.to_json)
 
@@ -444,12 +444,20 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
     end
 
     it 'fails if token_endpoint_auth_signing_alg_values_supported is an array with a non-string element' do
-      config = { token_endpoint_auth_signing_alg_values_supported: ['http://abc', 1] }
+      config = { token_endpoint_auth_signing_alg_values_supported: ['RS256', 1] }
 
       result = run(test, config_json: config.to_json)
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match(/Array of strings/)
+    end
+
+    it 'fails if token_endpoint_auth_signing_alg_values_supported is an empty array' do
+      config = {token_endpoint_auth_signing_alg_values_supported: []}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('fail')
     end
   end
 

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 RSpec.describe FASTSecurity::DiscoveryGroup do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('fast_security') }
   let(:group) { suite.groups[0] }
@@ -629,6 +631,42 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
 
         expect(result.result).to eq('pass')
       end
+    end
+  end
+
+  describe 'udap_authorization_extensions_supported field test' do 
+    let(:test) { group.tests[15] }
+
+    it 'fails if field is not present' do
+      config = {}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('fail')
+    end
+
+    it 'fails if udap_authorization_extensions_supported value is not an array' do
+      config = {udap_authorization_extensions_supported: 'hl7-b2b'}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('fail')
+    end
+
+    it 'passes if array is empty' do
+      config = {udap_authorization_extensions_supported: []}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('pass')
+    end
+
+    it 'passes if array includes a string' do 
+      config = {udap_authorization_extensions_supported: ['hl7-b2b']}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('pass')
     end
   end
 end

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -669,4 +669,51 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
       expect(result.result).to eq('pass')
     end
   end
+
+  describe 'udap_authorization_extensions_required field test' do 
+    let(:test) { group.tests[16] }
+
+    it 'skips if udap_authorization_extensions_supported field is not present' do
+      config = {}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('skip')
+    end
+
+    it 'omits if udap_authorization_extensions_supported field is present but empty' do
+      config = {udap_authorization_extensions_supported: []}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('omit')
+    end
+
+    context 'udap_authorization_extensions_supported is present and not empty' do
+
+      it 'fails if udap_authorization_extensions_required field is missing' do
+        config = {udap_authorization_extensions_supported: ['hl7-b2b']}
+
+        result = run(test, config_json: config.to_json)
+
+        expect(result.result).to eq('fail')
+      end
+
+      it 'passes if udap_authorization_extensions_required field is an empty array' do
+        config = {udap_authorization_extensions_supported: ['hl7-b2b'], udap_authorization_extensions_required: []}
+
+        result = run(test, config_json: config.to_json)
+
+        expect(result.result).to eq('pass')
+      end
+
+      it 'passes if array includes a string' do 
+        config = {udap_authorization_extensions_supported: ['hl7-b2b'], udap_authorization_extensions_required: ['hl7-b2b']}
+
+        result = run(test, config_json: config.to_json)
+
+        expect(result.result).to eq('pass')
+      end
+    end
+  end
 end

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -574,4 +574,61 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
       expect(result.result).to eq('pass')
     end
   end
+
+  describe 'udap_profiles_supported field test' do 
+    let(:test) { group.tests[14] }
+
+    it 'fails if field is not present' do
+      config = {}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('fail')
+    end
+
+    it 'passes if udap_profiles_supported is an array of two or more strings containing "udap_dcr" and "udap_authn"' do 
+      config = {udap_profiles_supported: ['udap_dcr', 'udap_authn']}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('pass')
+    end
+
+    it 'fails if udap_profiles_supported is not an array' do 
+      config = {udap_profiles_supported: 'udap_dcr'}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/be an Array/)
+    end
+
+    it 'fails if udap_profiles_supported is an array with a non-string element' do
+      config = {udap_profiles_supported: ['udap_dcr', 1]}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('fail')
+      expect(result.result_message).to match(/Array of strings/)
+    end
+
+    context 'client_credentials grant type is included in grant_types_supported' do
+
+      it 'fails if udap_profiles_supported does not include "udap_authz"' do 
+        config = {grant_types_supported: ['client_credentials'],udap_profiles_supported: ['udap_dcr', 'udap_authn']}
+
+        result = run(test, config_json: config.to_json)
+
+        expect(result.result).to eq('fail')
+      end
+
+      it 'passes if udap_profiles_supported includes "udap_authz"' do 
+        config = {grant_types_supported: ['client_credentials'],udap_profiles_supported: ['udap_dcr', 'udap_authn', 'udap_authz']}
+        
+        result = run(test, config_json: config.to_json)
+
+        expect(result.result).to eq('pass')
+      end
+    end
+  end
 end

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 RSpec.describe FASTSecurity::DiscoveryGroup do
   let(:suite) { Inferno::Repositories::TestSuites.new.find('fast_security') }
   let(:group) { suite.groups[0] }

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -389,12 +389,12 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'token_endpoint_auth_methods_supported field test' do
     let(:test) { group.tests[8] }
 
-    it 'omits if field is not present' do
+    it 'fails if field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
     end
 
     it 'passes if token_endpoint_auth_methods_supported is ["private_key_jwt"]' do

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'udap_certifications_supported field test' do
     let(:test) { group.tests[2] }
 
-    it 'omits if field is not present' do
+    it 'fails if field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
     end
 
     it 'passes if udap_certifications_supported is an array of uri strings' do
@@ -141,16 +141,25 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'udap_certifications_required field test' do
     let(:test) { group.tests[3] }
 
-    it 'omits if field is not present' do
+    it 'skips if udap_certifications_supported field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
+      expect(result.result).to eq('skip')
+    end
+
+    it 'omits if no UDAP certifications are supported' do 
+      config = { udap_certifications_supported: [ ]}
+      
+      result = run(test, config_json: config.to_json)
+
       expect(result.result).to eq('omit')
+
     end
 
     it 'passes if udap_certifications_required is an array of uri strings' do
-      config = { udap_certifications_required: ['http://abc', 'http://def'] }
+      config = { udap_certifications_supported: ['http://abc', 'http://def'],   udap_certifications_required: ['http://abc', 'http://def'] }
 
       result = run(test, config_json: config.to_json)
 
@@ -158,7 +167,7 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
     end
 
     it 'fails if udap_certifications_required is not an array' do
-      config = { udap_certifications_required: 'http://abc' }
+      config = { udap_certifications_supported: ['http://abc', 'http://def'],udap_certifications_required: 'http://abc' }
 
       result = run(test, config_json: config.to_json)
 
@@ -167,7 +176,7 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
     end
 
     it 'fails if udap_certifications_required is an array with a non-string element' do
-      config = { udap_certifications_required: ['http://abc', 1] }
+      config = { udap_certifications_supported: ['http://abc', 'http://def'],udap_certifications_required: ['http://abc', 1] }
 
       result = run(test, config_json: config.to_json)
 
@@ -176,7 +185,7 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
     end
 
     it 'fails if udap_certifications_required is an array with a non-uri string element' do
-      config = { udap_certifications_required: ['http://abc', 'def'] }
+      config = { udap_certifications_supported: ['http://abc', 'http://def'],udap_certifications_required: ['http://abc', 'def'] }
 
       result = run(test, config_json: config.to_json)
 

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -540,12 +540,12 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'signed_metadata field test' do
     let(:test) { group.tests[12] }
 
-    it 'omits if field is not present' do
+    it 'fails if field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
-      expect(result.result).to eq('omit')
+      expect(result.result).to eq('fail')
     end
 
     it 'fails if signed_metadata is not a String' do

--- a/spec/fast_security/discovery_group_spec.rb
+++ b/spec/fast_security/discovery_group_spec.rb
@@ -188,20 +188,12 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
   describe 'grant_types_supported field test' do
     let(:test) { group.tests[4] }
 
-    it 'omits if field is not present' do
+    it 'fails if field is not present' do
       config = {}
 
       result = run(test, config_json: config.to_json)
 
-      expect(result.result).to eq('omit')
-    end
-
-    it 'passes if grant_types_supported is an array of uri strings' do
-      config = { grant_types_supported: ['http://abc', 'http://def'] }
-
-      result = run(test, config_json: config.to_json)
-
-      expect(result.result).to eq('pass')
+      expect(result.result).to eq('fail')
     end
 
     it 'fails if grant_types_supported is not an array' do
@@ -211,6 +203,14 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match(/be an Array/)
+    end
+
+    it 'fails if array is present but empty' do
+      config = { grant_types_supported: []}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('fail')
     end
 
     it 'fails if grant_types_supported is an array with a non-string element' do
@@ -229,6 +229,14 @@ RSpec.describe FASTSecurity::DiscoveryGroup do
 
       expect(result.result).to eq('fail')
       expect(result.result_message).to match(/authorization_code/)
+    end
+
+    it 'passes if grant_types_supported includes a valid grant type' do
+      config = { grant_types_supported: ['client_credentials']}
+
+      result = run(test, config_json: config.to_json)
+
+      expect(result.result).to eq('pass')
     end
   end
 


### PR DESCRIPTION
# Summary
Updated discovery tests and specs to conform to the requirements in the most recent published version of the [UDAP/Security for Scalable Registration, Authentication, and Authorization IG (STU 1.0.0)](https://hl7.org/fhir/us/udap-security/discovery.html).  

Summary of changes includes:
1. Ensuring all required data items are present in the discovery response
2. Adding tests for additional required data items that were not present before
3. Adding or updating dependencies between fields (e.g., if one field has a certain value, then another field must be present)

# Testing Guidance
There is no reference server to run these tests against but they can be visualized by running the web browser.  

Spec tests were completed for all tests except the `signed_metadata` contents test, which would require a mocked cert, and can be run in the root project directory with `bundle exec rspec`.  
