### PR TITLE
FI-2429: Remove validator

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,1 @@
-VALIDATOR_URL=http://localhost/validatorapi
 REDIS_URL=redis://localhost:6379/0

--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,1 @@
 REDIS_URL=redis://redis:6379/0
-VALIDATOR_URL=http://validator_service:4567

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
-    inferno_core (0.4.33)
+    inferno_core (0.4.34)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -180,13 +180,14 @@ GEM
       base64
     kramdown (2.4.0)
       rexml
-    method_source (1.0.0)
+    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0305)
     minitest (5.22.3)
     multi_json (1.15.0)
-    multi_xml (0.6.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     multipart-post (2.4.0)
     mustermann (1.1.2)
       ruby2_keywords (~> 0.0.1)
@@ -195,11 +196,11 @@ GEM
       mustermann (= 1.1.2)
     netrc (0.11.0)
     nio4r (2.7.1)
-    nokogiri (1.16.3-arm64-darwin)
+    nokogiri (1.16.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-darwin)
+    nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.3-x86_64-linux)
+    nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -287,6 +288,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-linux
 

--- a/config/nginx.background.conf
+++ b/config/nginx.background.conf
@@ -53,34 +53,34 @@ http {
     # the server will close connections after this time
     keepalive_timeout 600;
 
-    location /validator {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://fhir_validator_app;
-    }
-
-    location /validatorapi/ {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://validator_service:4567/;
-    }
+#    location /validator {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://fhir_validator_app;
+#    }
+#
+#    location /validatorapi/ {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://validator_service:4567/;
+#    }
   }
 }

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -68,34 +68,34 @@ http {
       proxy_pass http://inferno:4567;
     }
 
-    location /validator {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://fhir_validator_app;
-    }
-
-    location /validatorapi/ {
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $http_host;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Port $server_port;
-      proxy_redirect off;
-      proxy_set_header Connection '';
-      proxy_http_version 1.1;
-      chunked_transfer_encoding off;
-      proxy_buffering off;
-      proxy_cache off;
-
-      proxy_pass http://validator_service:4567/;
-    }
+#    location /validator {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://fhir_validator_app;
+#    }
+#
+#    location /validatorapi/ {
+#      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#      proxy_set_header Host $http_host;
+#      proxy_set_header X-Forwarded-Proto $scheme;
+#      proxy_set_header X-Forwarded-Port $server_port;
+#      proxy_redirect off;
+#      proxy_set_header Connection '';
+#      proxy_http_version 1.1;
+#      chunked_transfer_encoding off;
+#      proxy_buffering off;
+#      proxy_cache off;
+#
+#      proxy_pass http://validator_service:4567/;
+#    }
   }
 }

--- a/docker-compose.background.yml
+++ b/docker-compose.background.yml
@@ -1,17 +1,17 @@
 version: '3'
 services:
-  validator_service:
-    image: infernocommunity/fhir-validator-service
-    # Update this path to match your directory structure
-    volumes:
-      - ./lib/fast_security/igs:/home/igs
-  fhir_validator_app:
-    image: infernocommunity/fhir-validator-app
-    depends_on:
-      - validator_service
-    environment:
-      EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
-      VALIDATOR_BASE_PATH: /validator
+  # validator_service:
+  #   image: infernocommunity/fhir-validator-service
+  #   # Update this path to match your directory structure
+  #   volumes:
+  #     - ./lib/fast_security/igs:/home/igs
+  # fhir_validator_app:
+  #   image: infernocommunity/fhir-validator-app
+  #   depends_on:
+  #     - validator_service
+  #   environment:
+  #     EXTERNAL_VALIDATOR_URL: http://localhost/validatorapi
+  #     VALIDATOR_BASE_PATH: /validator
   nginx:
     image: nginx
     volumes:
@@ -19,8 +19,8 @@ services:
     ports:
       - "80:80"
     command: [nginx, '-g', 'daemon off;']
-    depends_on:
-      - fhir_validator_app
+    # depends_on:
+    #   - fhir_validator_app
   redis:
     image: redis
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: ./
     volumes:
       - ./data:/opt/inferno/data
-    depends_on:
-      - validator_service
+    # depends_on:
+    #   - validator_service
   worker:
     build:
       context: ./
@@ -15,14 +15,14 @@ services:
     command: bundle exec sidekiq -r ./worker.rb
     depends_on:
       - redis
-  validator_service:
-    extends:
-      file: docker-compose.background.yml
-      service: validator_service
-  fhir_validator_app:
-    extends:
-      file: docker-compose.background.yml
-      service: fhir_validator_app
+  # validator_service:
+  #   extends:
+  #     file: docker-compose.background.yml
+  #     service: validator_service
+  # fhir_validator_app:
+  #   extends:
+  #     file: docker-compose.background.yml
+  #     service: fhir_validator_app
   nginx:
     extends:
       file: docker-compose.background.yml


### PR DESCRIPTION
# Summary
We're migrating to the HL7 validator wrapper, but this test kit doesn't currently validate any resources and the IG doesn't even define any profiles so this PR just disables the old validator without adding the new one.

This feels like a good test kit to remove the validator completely rather than just comment it out, but for consistency with the others it's commented out, in case someone really wants the validator UI.

Also bumps inferno_core while we're here.

# Testing Guidance
All tests should produce the same results as prod